### PR TITLE
feat: conformer-ctc 모델 연동

### DIFF
--- a/app/api/endpoints/voice.py
+++ b/app/api/endpoints/voice.py
@@ -7,16 +7,23 @@ from fastapi import APIRouter, Response, UploadFile, Form, File
 from fastapi.responses import FileResponse
 
 sys.path.append(os.path.dirname(os.path.abspath(os.path.dirname(__file__))))
-from model import whisper
+from model import whisper, conformer
 
 logging.basicConfig(level=logging.INFO)
 router = APIRouter()
 
 
-@router.post("/whisper", response_class=FileResponse)
+@router.post("/whisper")
 def _whisper(audio_file: UploadFile = File(), answer: str = Form()):
-
     recognized_text, cer = whisper.speech_to_text(audio_file, answer)
+    print(recognized_text, cer)
+    output = {"recognized_text": recognized_text, "cer": cer}
+    return Response(content=json.dumps(output), media_type="application/json")
+
+
+@router.post("/conformer")
+def _conformer(audio_file: UploadFile = File(), answer: str = Form()):
+    recognized_text, cer = conformer.speech_to_text(audio_file, answer)
     print(recognized_text, cer)
     output = {"recognized_text": recognized_text, "cer": cer}
     return Response(content=json.dumps(output), media_type="application/json")

--- a/app/api/model/conformer.py
+++ b/app/api/model/conformer.py
@@ -1,0 +1,26 @@
+import os
+
+from functools import lru_cache
+import nemo.collections.asr as nemo_asr
+
+from .utils import get_cer
+
+
+@lru_cache
+def get_conformer_ctc():
+    model = nemo_asr.models.ASRModel.restore_from("Conformer-CTC-BPE-8000-KOR.nemo")
+    return model
+
+
+def speech_to_text(audio_file, answer):
+    model = get_conformer_ctc()
+    path = f"temp/{audio_file.filename}"
+    with open(path, "wb") as f:
+        f.write(audio_file.file.read())
+
+    result = model.transcribe([path])
+    os.remove(path)
+    prediction = result[0]
+    _cer = get_cer(answer, prediction)['cer']
+
+    return prediction, _cer * 100

--- a/app/api/model/utils.py
+++ b/app/api/model/utils.py
@@ -1,0 +1,111 @@
+from typing import Tuple
+import jiwer
+import json
+
+
+def get_cer(reference, transcription, rm_punctuation = True) -> json:
+
+    # 문자 오류율(CER)은 자동 음성 인식 시스템의 성능에 대한 일반적인 메트릭입니다.
+    # CER은 WER(단어 오류율)과 유사하지만 단어 대신 문자에 대해 작동합니다.
+    # 이 코드에서는 문제는 사람들이 띄어쓰기를 지키지 않고 작성한 텍스트를 컴퓨터가 정확하게 인식하는 것이 매우 어렵기 때문에 인식에러에서 생략합니다.
+    # CER의 출력은 특히 삽입 수가 많은 경우 항상 0과 1 사이의 숫자가 아닙니다. 이 값은 종종 잘못 예측된 문자의 백분율과 연관됩니다. 값이 낮을수록 좋습니다.
+    # CER이 0인 ASR 시스템의 성능은 완벽한 점수입니다.
+
+    # CER = (S + D + I) / N = (S + D + I) / (S + D + C)
+    # S is the number of the substitutions,
+    # D is the number of the deletions,
+    # I is the number of the insertions,
+    # C is the number of the correct characters,
+    # N is the number of the characters in the reference (N=S+D+C).
+
+    refs = jiwer.RemoveWhiteSpace(replace_by_space=False)(reference)
+    trans = jiwer.RemoveWhiteSpace(replace_by_space=False)(transcription)
+
+    if rm_punctuation == True:
+        refs = jiwer.RemovePunctuation()(refs)
+        trans = jiwer.RemovePunctuation()(trans)
+    else:
+        refs = reference
+        trans = transcription
+
+    [hits, cer_s, cer_d, cer_i] = _measure_cer(refs, trans)
+
+    substitutions = cer_s
+    deletions = cer_d
+    insertions = cer_i
+
+    incorrect = substitutions + deletions + insertions
+    total = substitutions + deletions + hits + insertions
+
+    cer = incorrect / total
+
+    result = {'cer' : cer, 'substitutions' : substitutions, 'deletions' : deletions, 'insertions': insertions }
+
+    #return cer, substitutions, deletions, insertions
+    return result
+
+
+def levenshtein(u, v):
+    prev = None
+    curr = [0] + list(range(1, len(v) + 1))
+    # Operations: (SUB, DEL, INS)
+    prev_ops = None
+    curr_ops = [(0, 0, i) for i in range(len(v) + 1)]
+    for x in range(1, len(u) + 1):
+        prev, curr = curr, [x] + ([None] * len(v))
+        prev_ops, curr_ops = curr_ops, [(0, x, 0)] + ([None] * len(v))
+        for y in range(1, len(v) + 1):
+            delcost = prev[y] + 1
+            addcost = curr[y - 1] + 1
+            subcost = prev[y - 1] + int(u[x - 1] != v[y - 1])
+            curr[y] = min(subcost, delcost, addcost)
+            if curr[y] == subcost:
+                (n_s, n_d, n_i) = prev_ops[y - 1]
+                curr_ops[y] = (n_s + int(u[x - 1] != v[y - 1]), n_d, n_i)
+            elif curr[y] == delcost:
+                (n_s, n_d, n_i) = prev_ops[y]
+                curr_ops[y] = (n_s, n_d + 1, n_i)
+            else:
+                (n_s, n_d, n_i) = curr_ops[y - 1]
+                curr_ops[y] = (n_s, n_d, n_i + 1)
+    return curr[len(v)], curr_ops[len(v)]
+
+
+def _measure_cer(
+        reference : str, transcription : str
+) -> Tuple[int, int, int, int]:
+    """
+    소스 단어를 대상 단아로 변환하는 데 필요한 편집 작업(삭제, 삽입, 바꾸기)의 수를 확인합니다.
+    hints 횟수는 소스 딘아의 전체 길이에서 삭제 및 대체 횟수를 빼서 제공할 수 있습니다.
+
+    :param transcription: 대상 단어로 변환할 소스 문자열
+    :param reference: 소스 단어
+    :return: a tuple of #hits, #substitutions, #deletions, #insertions
+    """
+
+    ref, hyp = [], []
+
+    ref.append(reference)
+    hyp.append(transcription)
+
+    cer_s, cer_i, cer_d, cer_n = 0, 0, 0, 0
+    sen_err = 0
+
+    for n in range(len(ref)):
+        # update CER statistics
+        _, (s, i, d) = levenshtein(hyp[n], ref[n])
+        cer_s += s
+        cer_i += i
+        cer_d += d
+        cer_n += len(ref[n])
+
+        # update SER statistics
+        if s + i + d > 0:
+            sen_err += 1
+
+    substitutions = cer_s
+    deletions = cer_d
+    insertions = cer_i
+    hits = len(reference) - (substitutions + deletions) #correct characters
+
+    return hits, substitutions, deletions, insertions


### PR DESCRIPTION
## Summary
### Conformer-CTC
![image](https://user-images.githubusercontent.com/86872575/195866138-24f757f8-f5d2-43f3-8b50-cf934cc51652.png)
### Whisper
![image](https://user-images.githubusercontent.com/86872575/195867091-824d7264-67d2-44d5-9d2b-5a1fc37166f7.png)
## Describe your changes
- Conformer-CTC 모델을 사용한 ASR api 구현
- conformer-ctc 오픈 코드를 봤는데, Whisper 모델과 마찬가지로, 파일 경로로 audio file을 load하는 구조
- 수정하려고 뜯어 봤지만, 모델 관련 지식이 없는 상태에서 하기에는 복잡함
- 그래서 request로 넘어온 음성 파일을 temp 폴더에 잠시 저장했다가, 삭제하는 방식으로 구현함. -> 이게 맞는 방식일 지는 모르겠음
## Issue number and link
#8 
## PR CheckList
- [ ] Tests for the changes have been added (for bug fixes / features)